### PR TITLE
Progress towards building a native image with qbicc

### DIFF
--- a/Dockerfile.qbicc
+++ b/Dockerfile.qbicc
@@ -1,0 +1,31 @@
+FROM eclipse-temurin:17-focal
+LABEL maintainer="Ansu Varghese <avarghese@us.ibm.com>"
+
+#Dockerfile input is the class name whose native image must be generated
+ARG CLASS_NAME="Hello"
+
+WORKDIR /jdwp
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+&& apt-get -qqy update \
+&& apt-get -qqy install \
+  build-essential \
+  maven \
+  lsb-release \
+  wget \
+  libunwind-dev \
+  software-properties-common
+
+# Install LLVM 13
+RUN wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 13 && rm llvm.sh
+
+# Install jbang
+RUN curl -Ls https://sh.jbang.dev | bash -s - app setup
+
+COPY nativeImageGenQbicc.sh .
+COPY src/$CLASS_NAME ./src/$CLASS_NAME
+
+ENV CLASS_NAME=$CLASS_NAME
+ENV QBICC_VERSION=0.24.0
+
+ENTRYPOINT ./nativeImageGenQbicc.sh -c $CLASS_NAME -q $QBICC_VERSION

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,19 @@ nativeimage: ## Run a container to generate a native image executable and debug 
 	docker build -t $(NATIVEIMAGE) --build-arg CLASS_NAME=$(CLASSNAME) -f Dockerfile .
 	docker run --privileged --name $(NATIVEIMAGE) -v $(PWD)/../nativejdb/apps:/jdwp/apps $(NATIVEIMAGE)
 
+nativeimageqbicc: ## Run a container to generate a native image executable and debug sources for CLASS_NAME app.
+	docker stop $(NATIVEIMAGE).qbicc && docker rm $(NATIVEIMAGE).qbicc || exit 0;
+	docker build -t $(NATIVEIMAGE).qbicc --build-arg CLASS_NAME=$(CLASSNAME) -f Dockerfile.qbicc .
+	docker run --privileged --name $(NATIVEIMAGE).qbicc -v $(PWD)/../nativejdb/apps:/jdwp/apps $(NATIVEIMAGE).qbicc
+
 exec: ## Exec into NATIVEIMAGE container.
 	docker exec -it $(NATIVEIMAGE) /bin/bash
 
 build: ## Build NATIVEIMAGE container.
 	docker build -t $(NATIVEIMAGE) --build-arg REBUILD_EXEC=$(REBUILD) .
+
+buildqbicc: ## Build NATIVEIMAGE container.
+	docker build -t $(NATIVEIMAGE).qbicc --build-arg REBUILD_EXEC=$(REBUILD) -f Dockerfile.qbicc .
 
 run: ## Start NATIVEIMAGE container.
 	docker run --privileged --name $(NATIVEIMAGE) -v $(PWD)/apps:/jdwp/apps $(NATIVEIMAGE)

--- a/nativeImageGenQbicc.sh
+++ b/nativeImageGenQbicc.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+while getopts c:q: flag
+do
+    case "${flag}" in
+        c) CLASS_NAME=${OPTARG};;
+        q) QBICC_VERSION=${OPTARG};;
+        *) ;;
+    esac
+done
+
+cp -r src/* apps/
+javac apps/$CLASS_NAME/*.java
+
+IMAGE_NAME=debugeeImg
+
+export PATH=/usr/lib/llvm-13/bin:$HOME/.jbang/bin:$PATH
+
+export JDK_JAVA_OPTIONS=-Xss8m
+
+# Make a jar file containing the input program
+cd /jdwp/apps
+jar -cfe $CLASS_NAME.jar $CLASS_NAME/$CLASS_NAME $CLASS_NAME/*.class
+
+
+# Using qbicc to build a native image.
+# Leave the 1000s of .ll and .s files in /tmp/output and only
+# copy the actual executable to the /jdwp/apps volume.
+rm -rf /tmp/output
+jbang org.qbicc:qbicc-main:$QBICC_VERSION --boot-path-append-file $CLASS_NAME.jar --output-path /tmp/output -o $IMAGE_NAME $CLASS_NAME/$CLASS_NAME && cp /tmp/output/$IMAGE_NAME /jdwp/apps/$IMAGE_NAME
+
+
+
+#Exit with status of process
+exit $?


### PR DESCRIPTION
This "works" except for a path problem I'm still debugging that is causing qbicc to use `gcc` instead of `clang` to assemble the output .s files.  This doesn't work, so the compilation of .s into .o files currently fails.